### PR TITLE
fix: prevent demo2 prototype from blocking web build

### DIFF
--- a/apps/web/app/demo2-prototype/page.tsx
+++ b/apps/web/app/demo2-prototype/page.tsx
@@ -5,7 +5,34 @@ import PrototypeFrame from './PrototypeFrame'
 
 export default async function Demo2PrototypePage() {
   const prototypePath = path.join(process.cwd(), '..', '..', 'docs', 'design_refs', 'Atlax_MindDock_Landing_Page.txt')
-  const html = await readFile(prototypePath, 'utf8')
+  let html: string | null = null
+
+  try {
+    html = await readFile(prototypePath, 'utf8')
+  } catch (error) {
+    if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') {
+      throw error
+    }
+  }
+
+  if (!html) {
+    return (
+      <main className="min-h-screen bg-slate-950 text-slate-100 flex items-center justify-center px-6">
+        <section className="max-w-xl">
+          <p className="text-sm font-medium uppercase tracking-[0.2em] text-slate-500">Demo2 Prototype</p>
+          <h1 className="mt-4 text-2xl font-semibold">Design reference unavailable</h1>
+          <p className="mt-3 text-sm leading-6 text-slate-400">
+            This development reference page expects a local prototype file at
+            {' '}
+            <code className="rounded bg-white/10 px-1.5 py-0.5 text-slate-200">
+              docs/design_refs/Atlax_MindDock_Landing_Page.txt
+            </code>
+            . The main web build can continue without that optional file.
+          </p>
+        </section>
+      </main>
+    )
+  }
 
   return <PrototypeFrame html={html} />
 }


### PR DESCRIPTION
## Summary

This PR fixes the post-merge `origin/develop` web build blocker introduced by the `/demo2-prototype` route.

## Fix reason

After PR #12 was squash-merged into `develop`, `pnpm validate` passed but `pnpm build:web` failed during Next.js prerender for `/demo2-prototype` because the route directly called `readFile` on a missing optional design reference file:

```text
docs/design_refs/Atlax_MindDock_Landing_Page.txt
```

## Fix scope

- Updated `apps/web/app/demo2-prototype/page.tsx` only.
- The route still reads and renders the prototype HTML when the local design reference file exists.
- If the optional file is missing, the route renders a safe fallback page instead of blocking the production web build.
- Non-ENOENT file read errors are still re-thrown.

## Validation

- `pnpm install`: passed
- `pnpm validate`: passed
- `pnpm build:web`: passed

## Not included

This PR does not:

- Implement Local Core
- Add or integrate Desktop Runtime
- Add Tauri / Electron
- Modify `stable-demo`
- Modify `main`
- Add product functionality
- Refactor Workspace
